### PR TITLE
Added project preview tool

### DIFF
--- a/_layouts/base.md
+++ b/_layouts/base.md
@@ -65,6 +65,8 @@
 
 <script src="/assets/js/docs.js"></script>
 {% include analytics.html %}
-{% include footer.html %}
+{% if page.nofooter == nil %}
+    {% include footer.html %}
+{% endif %}    
 </body>
 </html>

--- a/_layouts/basic.md
+++ b/_layouts/basic.md
@@ -2,7 +2,10 @@
 layout: base
 ---
 <header class="navbar navbar-inverse navbar-static-top">
+  {% if page.noribbon == nil %}
   <a href="https://github.com/formio/help.form.io"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>
+  {% endif %}   
+
   <div class="container">
     <div class="navbar-header">
       <a class="navbar-brand" href="/">

--- a/project.html
+++ b/project.html
@@ -1,0 +1,143 @@
+---
+layout: basic
+app: formioProject
+controller: ProjectController
+nofooter: true
+noribbon: true
+---
+<style>
+    html, body {
+        width: 100%;
+        height: 100%;
+    }
+    body {
+        display: table;
+    }
+    #preview-container {
+        display: table-row;
+        height: 100%;
+    }
+    iframe {
+        height: 100%;
+        width: 100%;
+        border-top: 1px solid lightgray;
+    }
+
+</style>
+<div class="container" >
+    <div class="row">
+        <div class="panel panel-default" ng-if="!showPreview">
+            <div class="panel-heading">
+                <div>Enter the project name and preview url into the box below and press <strong>Preview</strong> to preview the project.</div>
+            </div>
+            <div class="panel-body">
+                <form name="form" ng-submit="onSubmit()">
+                    <div class="form-group" ng-class="{'has-error': form.project.$invalid && form.project.$dirty}">
+                        <label class="control-label" for="project">Project Name</label>
+                        <div class="input-group" style="width: 300px;">
+                            <span class="input-group-addon">https://</span>
+                            <input type="text" name="project" id="project" class="form-control" placeholder="myproject" ng-model="data.project" ng-required="true">
+                            <span class="input-group-addon">.form.io</span>
+                        </div>
+                        <p class="help-block" ng-show="form.project.$error.required && form.project.$dirty">Project Name is required.</p>
+                    </div>
+                    <div class="form-group" ng-class="{'has-error': form.previewUrl.$invalid && form.previewUrl.$dirty}">
+                        <label class="control-label" for="previewUrl">Preview App URL</label>
+                        <input type="url" name="previewUrl" id="previewUrl" class="form-control" placeholder="http://formio.github.io/formio-app-todo" ng-model="data.previewUrl" ng-required="true">
+                        <p class="help-block" ng-show="form.previewUrl.$error.required && form.previewUrl.$dirty">Preview URL is required.</p>
+                        <p class="help-block" ng-show="form.previewUrl.$error.url && form.previewUrl.$dirty">Must be a valid URL (<code class="text-muted">http://www.example.com</code>).</p>
+                    </div>
+                    <button class="btn btn-primary" type="submit" ng-disabled="form.$invalid">Preview</button>
+                </form>
+            </div>
+        </div>
+        <div ng-if="showPreview">
+            <p>
+                You are viewing a preview of <strong ng-bind="decodeURIComponent(getAppUrl())"></strong>
+                <a href="/project" class="btn btn-default pull-right">Reset</a>
+            </p>
+            <p ng-if="data.repo">Want to modify or host this app yourself? Check out the <a {% raw %}ng-href="{{data.repo}}"{% endraw %}>source code</a>.</p>
+        </div>
+    </div>
+</div>
+<div id="preview-container" ng-if="showPreview">
+    <iframe {% raw %}ng-src="{{ getPreviewUrl() }}"{% endraw $} frameborder="0"></iframe>
+</div>
+<script type="text/javascript">
+    var QueryString = function () {
+        // This function is anonymous, is executed immediately and
+        // the return value is assigned to QueryString!
+        var query_string = {};
+        var query = window.location.search.substring(1);
+        var vars = query.split("&");
+        for (var i=0;i<vars.length;i++) {
+            var pair = vars[i].split("=");
+            // If first entry with this name
+            if (typeof query_string[pair[0]] === "undefined") {
+                query_string[pair[0]] = decodeURIComponent(pair[1]);
+                // If second entry with this name
+            } else if (typeof query_string[pair[0]] === "string") {
+                var arr = [ query_string[pair[0]],decodeURIComponent(pair[1]) ];
+                query_string[pair[0]] = arr;
+                // If third or later entry with this name
+            } else {
+                query_string[pair[0]].push(decodeURIComponent(pair[1]));
+            }
+        }
+        return query_string;
+    }();
+
+    angular.module('formioProject', ['formio'])
+        .controller('ProjectController', ['$scope', '$sce', function($scope, $sce) {
+            if(QueryString.project && QueryString.previewUrl) {
+                $scope.showPreview = true;
+            }
+
+            $scope.data = {
+                project: QueryString.project || '',
+                previewUrl: QueryString.previewUrl || '',
+                repo: QueryString.repo
+            };
+
+            $scope.onSubmit = function() {
+                // $scope.showPreview = true;
+                QueryString.project = $scope.data.project;
+                QueryString.previewUrl = $scope.data.previewUrl;
+                window.location.search = '?' +
+                    Object.keys(QueryString)
+                    .filter(function(key) {
+                        return key; // filter undefined keys
+                    })
+                    .map(function(key) {
+                        return key + '=' + encodeURIComponent(QueryString[key]);
+                    })
+                    .join('&');
+            };
+
+            $scope.getAppUrl = function() {
+                var host = QueryString.host || 'form.io';
+                var protocol = QueryString.protocol || 'https';
+                return encodeURIComponent(protocol + '://' + $scope.data.project + '.' + host);
+            }
+
+            $scope.getApiUrl = function() {
+                var host = QueryString.host || 'form.io';
+                var protocol = QueryString.protocol || 'https';
+                return encodeURIComponent(protocol + '://api.' + host);
+            }
+
+            $scope.decodeURIComponent = decodeURIComponent;
+
+            $scope.getPreviewUrl = function() {
+                // Optional settings not shown in form
+                var host = QueryString.host || 'form.io';
+                var protocol = QueryString.protocol || 'https';
+
+                // Build the url
+                var url = $scope.data.previewUrl;
+                url += '?appUrl=' + $scope.getAppUrl() + '&apiUrl=' + $scope.getApiUrl();
+
+                return $sce.trustAsResourceUrl(url);
+            };
+        }]);
+</script>


### PR DESCRIPTION
The tool is available on http://help.form.io/project

The tool lets you set the project name and url to the preview app. There are a few hidden options you can set via url query params:

 - host: The host of the project server (default: form.io)
 - protocol: The protocol of the project server (default: https)
 - repo: Link to the source code of the preview url (this is shown on page if given)

When previewing an app, the tool opens an iframe to the preview app url and passes the following url query params:

 - appUrl: {protocol}://{projectName}.{host}
 - apiUrl: {protocol}://api.{host}

The preview app should read these and use them as appropriate to point form.io forms to the right project.