### PR TITLE
Remove duplicate --restart unless-stopped doc

### DIFF
--- a/_paragraphs/userguide/environments/environments-docker.md
+++ b/_paragraphs/userguide/environments/environments-docker.md
@@ -79,7 +79,6 @@ docker run -itd \
   --name formio-server \
   --network formio \
   --link formio-mongo:mongo \
-  --restart unless-stopped \
   -p 3000:80 \
   formio/formio-enterprise;
 ```
@@ -100,7 +99,6 @@ docker run -itd \
   --name formio-server \
   --network formio \
   --link formio-mongo:mongo \
-  --restart unless-stopped \
   -p 3000:80 \
   formio/formio-enterprise;
 ```
@@ -151,7 +149,6 @@ docker run -itd \
   --name formio-server \
   --network formio \
   --link formio-mongo:mongo \
-  --restart unless-stopped \
   -p 3000:80 \
   formio/formio-enterprise;
 ```


### PR DESCRIPTION
Remove duplicate --restart unless-stopped from user guide examples of using docker